### PR TITLE
feat: add order list version2(paging & lite data)

### DIFF
--- a/src/main/java/com/wannistudio/wannimart/controller/order/OrderController.java
+++ b/src/main/java/com/wannistudio/wannimart/controller/order/OrderController.java
@@ -12,6 +12,8 @@ import com.wannistudio.wannimart.service.OrderService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,6 +41,12 @@ public class OrderController {
   @ApiOperation(value = "주문목록 조회 - 단순 주문목록")
   public ApiResult<List<OrderQueryDto>> orders() {
     return OK(orderService.findAllOrderQueryDto(new OrderSearch()));
+  }
+
+  @GetMapping(path = "/order/v2/list")
+  @ApiOperation(value = "주문목록 조회 - 페이징 처리 및 데이터 간소화")
+  public ApiResult<Page<OrderItemQueryDto>> orderItems(OrderSearch orderSearch, Pageable pageable) {
+    return OK(orderService.findAllOrderItemQueryDto(orderSearch, pageable));
   }
 
   @PostMapping(path = "/orders/{orderId}/cancel")

--- a/src/main/java/com/wannistudio/wannimart/repository/order/OrderRepositoryCustomQuery.java
+++ b/src/main/java/com/wannistudio/wannimart/repository/order/OrderRepositoryCustomQuery.java
@@ -1,11 +1,15 @@
 package com.wannistudio.wannimart.repository.order;
 
+import com.wannistudio.wannimart.controller.order.OrderItemQueryDto;
 import com.wannistudio.wannimart.controller.order.OrderQueryDto;
 import com.wannistudio.wannimart.domain.order.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface OrderRepositoryCustomQuery {
   List<Order> findAll(OrderSearch orderSearch);
   List<OrderQueryDto> findOrderQueryDtos(OrderSearch orderSearch);
+  Page<OrderItemQueryDto> findOrderItemQueryDtos(OrderSearch orderSearch, Pageable pageable);
 }

--- a/src/main/java/com/wannistudio/wannimart/service/OrderService.java
+++ b/src/main/java/com/wannistudio/wannimart/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.wannistudio.wannimart.service;
 
+import com.wannistudio.wannimart.controller.order.OrderItemQueryDto;
 import com.wannistudio.wannimart.controller.order.OrderQueryDto;
 import com.wannistudio.wannimart.domain.order.Order;
 import com.wannistudio.wannimart.domain.connect.OrderItem;
@@ -11,6 +12,8 @@ import com.wannistudio.wannimart.repository.member.MemberRepository;
 import com.wannistudio.wannimart.repository.order.OrderRepository;
 import com.wannistudio.wannimart.repository.order.OrderSearch;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +30,10 @@ public class OrderService {
 
   public List<OrderQueryDto> findAllOrderQueryDto(OrderSearch orderSearch) {
     return orderRepository.findOrderQueryDtos(orderSearch);
+  }
+
+  public Page<OrderItemQueryDto> findAllOrderItemQueryDto(OrderSearch orderSearch, Pageable pageable) {
+    return orderRepository.findOrderItemQueryDtos(orderSearch, pageable);
   }
 
   //주문


### PR DESCRIPTION
주문 리스트, 내 정보 -> 주문 목록에 필요한 데이터만 조회하고, 이 데이터들을 paging 하여, api 호출을 하도록 함.