### PR TITLE
feat: add jastpy fot encrypt sql datasource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <java.jwt.version>3.12.0</java.jwt.version>
         <springfox.swagger2.version>2.9.2</springfox.swagger2.version>
         <querydsl.version>4.4.0</querydsl.version>
+        <jasypt.version>3.0.3</jasypt.version>
     </properties>
 
     <dependencies>
@@ -132,6 +133,19 @@
             <groupId>com.querydsl</groupId>
             <artifactId>querydsl-jpa</artifactId>
             <version>${querydsl.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.ulisesbocchio</groupId>
+            <artifactId>jasypt-spring-boot-starter</artifactId>
+            <version>${jasypt.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.60</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/wannistudio/wannimart/InitDb.java
+++ b/src/main/java/com/wannistudio/wannimart/InitDb.java
@@ -7,6 +7,8 @@ import com.wannistudio.wannimart.domain.member.Member;
 import com.wannistudio.wannimart.service.CategoryService;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -15,16 +17,28 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
 
-@Profile(value = "local")
+@Profile(value = "dev")
 @Component
 @AllArgsConstructor
 public class InitDb {
   private final InitService initService;
 
+
   @PostConstruct
   public void init() {
-    initService.establishSampleMember();
-    initService.establishCategory();
+//    initService.establishSampleMember();
+//    initService.establishCategory();
+//    StandardPBEStringEncryptor pbeEnc = new StandardPBEStringEncryptor();
+//    pbeEnc.setPassword("wanni");
+//    pbeEnc.setAlgorithm("PBEWithMD5AndDES");
+//
+//    String url = "jdbc:postgresql://35.221.177.149:5432/wannimart";
+//    String username = "wanni";
+//    String password = "wanni0928";
+//
+//    System.out.println("변경된 url : " + pbeEnc.encrypt(url));
+//    System.out.println("변경된 username : " + pbeEnc.encrypt(username));
+//    System.out.println("변경된 password : " + pbeEnc.encrypt(password));
   }
 
   @Component

--- a/src/main/java/com/wannistudio/wannimart/config/JasyptConfig.java
+++ b/src/main/java/com/wannistudio/wannimart/config/JasyptConfig.java
@@ -1,0 +1,31 @@
+package com.wannistudio.wannimart.config;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableAutoConfiguration
+public class JasyptConfig {
+
+  @Bean("jasyptStringEncryptor")
+  public StringEncryptor stringEncryptor() {
+
+    PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+    SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+
+    config.setPassword("wanni");
+    config.setAlgorithm("PBEWithMD5AndDES");
+    config.setKeyObtentionIterations("1000");
+    config.setPoolSize("1");
+    config.setProviderName("SunJCE");
+    config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+    config.setStringOutputType("base64");
+    encryptor.setConfig(config);
+
+    return encryptor;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local
+    active: dev
   application:
     name: wannimart
   messages:
@@ -9,10 +9,16 @@ spring:
     cache-duration: PT1H
   jpa:
     hibernate:
+      ddl-auto: update
       use-new-id-generator-mappings: false
     properties:
       hibernate:
         hibernate.hbm2ddl.import_files_sql_extractor: org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor
+  datasource:
+    url: ENC(9EWEwraoTu4na1VrwLj5Hydjxg1LkhbJIFsablrqLgmtKpyT21Yse+FMtelLnLSz+cbDGPEQfQY=)
+    username: ENC(1BdP0PWDB4FHKMARcZwelQ==)
+    password: ENC(EyQMHXyxj2pNa62TuCNNvlcEf2IaITjI)
+
 jwt:
   token:
     header: api_key
@@ -20,16 +26,15 @@ jwt:
     clientSecret: Rel3Bjce2MajBo09qgkNgYaTuzvJe8iwnBFhsDS5
     expirySeconds: 6000
 
+jasypt:
+  encryptor:
+    bean: jasyptStringEncryptor
 ---
 #local 환경
 spring:
   config:
     activate:
       on-profile: local
-  datasource:
-    url: jdbc:postgresql://localhost:5432/wannimart
-    username: wanni
-    password: wanni0928
 
   jpa:
     show-sql: true
@@ -56,5 +61,4 @@ spring:
 logging:
   level:
     org.hibernate.SQL: info # logger 로 출력
-    org.hibernate.type: trace # 쿼리 파라미터 로그 출력
 ---


### PR DESCRIPTION
- properties yaml 파일 안에 datasource에 db명과 암호, 그리고, db가 설치된 인스턴스의 ip 주소를 깃헙 레포지토리에 그냥 올리는 것이 너무 신경쓰였다.
- 구글링을 통해 알아본 결과, properties 값들을 암호화 하는데에는 여러가지가 있지만, 가장 보편적인 것은 vault 와 jaspty 라이브러리였다.
- 둘다 보편적이고 검증된 방법이지만, 둘 중에서 레퍼런스가 더 많고, 시간도 적게 걸리는 방법으로는 jaspty여서 이 방식을 채택했다.
- dbms 인스턴스 주소로 작동이 되는지는 이미 확인이 된 상태다.