### PR TITLE
feat: configuration displayed swagger-ui (description, disable try it…

### DIFF
--- a/src/main/java/com/wannistudio/wannimart/WannimartApplication.java
+++ b/src/main/java/com/wannistudio/wannimart/WannimartApplication.java
@@ -2,12 +2,15 @@ package com.wannistudio.wannimart;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 
 @SpringBootApplication
 public class WannimartApplication {
 
   public static void main(String[] args) {
-    SpringApplication.run(WannimartApplication.class, args);
+    new SpringApplicationBuilder(WannimartApplication.class)
+            .properties("D:\\Users\\chju\\qqq.yml")
+            .run(args);
   }
 
 }

--- a/src/main/java/com/wannistudio/wannimart/config/common/Swagger2Configure.java
+++ b/src/main/java/com/wannistudio/wannimart/config/common/Swagger2Configure.java
@@ -15,6 +15,8 @@ import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger.web.SecurityConfiguration;
 import springfox.documentation.swagger.web.SecurityConfigurationBuilder;
+import springfox.documentation.swagger.web.UiConfiguration;
+import springfox.documentation.swagger.web.UiConfigurationBuilder;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 import java.util.List;
@@ -49,6 +51,13 @@ public class Swagger2Configure implements WebMvcConfigurer {
   }
 
   @Bean
+  public UiConfiguration uiConfig() {
+    return UiConfigurationBuilder.builder()
+            .supportedSubmitMethods(UiConfiguration.Constants.NO_SUBMIT_METHODS)
+            .build();
+  }
+
+  @Bean
   public SecurityConfiguration security() {
     return SecurityConfigurationBuilder.builder()
             .scopeSeparator(",")
@@ -68,6 +77,9 @@ public class Swagger2Configure implements WebMvcConfigurer {
   private ApiInfo apiInfo() {
     return new ApiInfoBuilder()
             .title("Wanni-Mart")
+            .description("online shop Order management api")
+            .license("Apache 2.0")
+            .licenseUrl("http://springdoc.org")
             .contact(new Contact("choi hyung joong", "https://github.com/wanni0928", "chlgudwnd123@gmail.com"))
             .version("1.0.0")
             .build();


### PR DESCRIPTION
- swagger-ui 를 검토중에, 'try it out'과 같은 버튼을 비활성화 시켰다.
- 비활성화 시킨 이유는 swagger-ui에 연결된 api 서버가 실제 배포할 서버와 연결되어 있어, 무분별한 시연(불특정 대다수의 어뷰징)을 방지하기 위해서다.
- 이 작업을 하면서, application.yml의 위치를 애플리케이션 외부로 옮겨서 슬쩍 시연을 해보았는데, 잘 작동하는 것을 알게 되었다. 해당 yml 파일을 애플리케이션 운영 서버에 숨겨놓으면, 안의 내용을 숨김과 동시에, 배포마다, 통합테스트를 아무문제 없이 진행할 수 있을 것 같다.